### PR TITLE
Refer to idr0037 in the screen description

### DIFF
--- a/idr0034-study.txt
+++ b/idr0034-study.txt
@@ -43,7 +43,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 							
 Screen Number	1						
 Comment[IDR Screen Name]	idr0034-kilpinen-hipsci/screenA						
-Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' have been released at this time (May 2017). An extended version of this screen is now available including all the data from this study. Please refer to idr0037-vigilante-hipsci for more details.						
+Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' were released in May 2017. This screen has been extended to include all data from this study.  Please refer to idr0037-vigilante-hipsci for more details.						
 Screen Size	Plates: 29	5D Images:6156	Planes:24624	Average Image Dimension (XYZCT):	Total Tb:0.11		
 Screen Example Images	https://idr.openmicroscopy.org/webclient/?show=well-1319381	https://idr.openmicroscopy.org/webclient/img_detail/3271621/	experiment_27;D10				
 Screen Imaging Method	fluorescence microscopy						

--- a/idr0034-study.txt
+++ b/idr0034-study.txt
@@ -11,14 +11,13 @@ Study Organism Term Source REF	NCBITaxon
 Study Organism Term Accession	NCBITaxon_9606						
 Study Screens Number	1						
 Study External URL	http://www.hipsci.org/	https://www.ebi.ac.uk/biostudies/studies/S-BSMS5/					
-Study Public Release Date							
-							
+Study Public Release Date													
 Study Version History	In February 2019, this screen was extended and 87 human induced pluripotent stem cell lines from 62 donors were added. All data from this study is included in idr0037-vigilante-hipsci.
 
 # Study Publication							
 Study PubMed ID	28489815						
 Study Publication Title	Common genetic variation drives molecular heterogeneity in human iPSCs						
-Study Author List	Helena Kilpinen, Angela Goncalves, Andreas Leha, Vackar Afzal, Sofie Ashford, Sendu Bala, Dalila Bensaddek, Francesco Paolo Casale, Oliver Culley, Petr Danecek, Adam Faulconbridge, Peter Harrison, Davis McCarthy, Shane A McCarthy, Ruta Meleckyte, Yasin Memari, Nathalie Moens, Filipa Soares, Ian Streeter, Chukwuma A Agu, Alex Alderton, Rachel Nelson, Sarah Harper, Minal Patel, Laura Clarke, Reena Halai, Christopher M Kirton, Anja Kolb-Kokocinski, Philip Beales, Ewan Birney, Davide Danovi, Angus I Lamond, Willem H Ouwehand, Ludovic Vallier, Fiona M Watt, Richard Durbin, Oliver Stegle, Daniel J Gaffney						
+Study Author List	Helena Kilpinen, Angela Goncalves, Andreas Leha, Vackar Afzal, Sofie Ashford, Sendu Bala, Dalila Bensaddek, Francesco Paolo Casale, Oliver Culley, Petr Danecek, Adam Faulconbridge, Peter Harrison, Davis McCarthy, Shane A McCarthy, Ruta Meleckyte, Yasin Memari, Nathalie Moens, Filipa Soares, Ian Streeter, Chukwuma A Agu, Alex Alderton, Rachel Nelson, Sarah Harper, Minal Patel, Laura Clarke, Reena Halai, Christopher M Kirton, Anja Kolb-Kokocinski, Philip Beales, Ewan Birney, Davide Danovi, Angus I Lamond, Willem H Ouwehand, Ludovic Vallier, Fiona M Watt, Richard Durbin, Oliver Stegle, Daniel J Gaffney
 Study PMC ID	PMC5524171						
 Study DOI	https://doi.org/10.1038/nature22403						
 							

--- a/idr0034-study.txt
+++ b/idr0034-study.txt
@@ -43,7 +43,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 							
 Screen Number	1						
 Comment[IDR Screen Name]	idr0034-kilpinen-hipsci/screenA						
-Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' have been released at this time (May 2017). An extended dataset in comparable conditions is due to be released in the future alongside associated studies.						
+Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' have been released at this time (May 2017). An extended version of this screen is now available including all the data from this study. Please refer to idr0037-vigilante-hipsci for more details.						
 Screen Size	Plates: 29	5D Images:6156	Planes:24624	Average Image Dimension (XYZCT):	Total Tb:0.11		
 Screen Example Images	https://idr.openmicroscopy.org/webclient/?show=well-1319381	https://idr.openmicroscopy.org/webclient/img_detail/3271621/	experiment_27;D10				
 Screen Imaging Method	fluorescence microscopy						

--- a/idr0034-study.txt
+++ b/idr0034-study.txt
@@ -13,6 +13,8 @@ Study Screens Number	1
 Study External URL	http://www.hipsci.org/	https://www.ebi.ac.uk/biostudies/studies/S-BSMS5/					
 Study Public Release Date							
 							
+Study Version History	In February 2019, this screen was extended and 87 human induced pluripotent stem cell lines from 62 donors were added. All data from this study is included in idr0037-vigilante-hipsci.
+
 # Study Publication							
 Study PubMed ID	28489815						
 Study Publication Title	Common genetic variation drives molecular heterogeneity in human iPSCs						
@@ -43,7 +45,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 							
 Screen Number	1						
 Comment[IDR Screen Name]	idr0034-kilpinen-hipsci/screenA						
-Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' were released in May 2017. This screen has now been extended to include all data from this study.  Please refer to idr0037-vigilante-hipsci for more details.						
+Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' were released in May 2017.						
 Screen Size	Plates: 29	5D Images:6156	Planes:24624	Average Image Dimension (XYZCT):	Total Tb:0.11		
 Screen Example Images	https://idr.openmicroscopy.org/webclient/?show=well-1319381	https://idr.openmicroscopy.org/webclient/img_detail/3271621/	experiment_27;D10				
 Screen Imaging Method	fluorescence microscopy						

--- a/idr0034-study.txt
+++ b/idr0034-study.txt
@@ -43,7 +43,7 @@ Term Source URI	http://purl.obolibrary.org/obo/	http://www.ebi.ac.uk/efo/	http:/
 							
 Screen Number	1						
 Comment[IDR Screen Name]	idr0034-kilpinen-hipsci/screenA						
-Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' were released in May 2017. This screen has been extended to include all data from this study.  Please refer to idr0037-vigilante-hipsci for more details.						
+Screen Description	Cellular phenotyping of 28 human induced pluripotent stem cell lines from 14 donors within the framework of the HipSci project. Cells are plated sparsely, 3000 per 96 well for 24 hours on wells coated with three diverse concentrations of Fibronectin. Note the images relating to the publication 'Common genetic variation drives molecular heterogeneity in human iPSCs' were released in May 2017. This screen has now been extended to include all data from this study.  Please refer to idr0037-vigilante-hipsci for more details.						
 Screen Size	Plates: 29	5D Images:6156	Planes:24624	Average Image Dimension (XYZCT):	Total Tb:0.11		
 Screen Example Images	https://idr.openmicroscopy.org/webclient/?show=well-1319381	https://idr.openmicroscopy.org/webclient/img_detail/3271621/	experiment_27;D10				
 Screen Imaging Method	fluorescence microscopy						


### PR DESCRIPTION
The upcoming release of the [idr0037-vigilante-hipsci](https://github.com/IDR/idr0037-vigilante-hipsci) study will contain all the data included in this study and effectively supersedes it.

Immediately, this tries to reformulate the `Screen description` which will be available from https://idr.openmicroscopy.org/webclient/?show=screen-1901 to indicate this concept.